### PR TITLE
Cudatoolkit9compat

### DIFF
--- a/cuda-samples/0_Simple/asyncAPI/Makefile
+++ b/cuda-samples/0_Simple/asyncAPI/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/clock/Makefile
+++ b/cuda-samples/0_Simple/clock/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/cppIntegration/Makefile
+++ b/cuda-samples/0_Simple/cppIntegration/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/cppOverload/Makefile
+++ b/cuda-samples/0_Simple/cppOverload/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/cudaOpenMP/Makefile
+++ b/cuda-samples/0_Simple/cudaOpenMP/Makefile
@@ -210,9 +210,9 @@ $(shell rm a.out test.c 2>/dev/null)
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/inlinePTX/Makefile
+++ b/cuda-samples/0_Simple/inlinePTX/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/matrixMul/Makefile
+++ b/cuda-samples/0_Simple/matrixMul/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/matrixMulCUBLAS/Makefile
+++ b/cuda-samples/0_Simple/matrixMulCUBLAS/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/matrixMulDrv/Makefile
+++ b/cuda-samples/0_Simple/matrixMulDrv/Makefile
@@ -201,7 +201,7 @@ $(foreach sm,$(SMS),$(eval GENCODE_FLAGS += -gencode arch=compute_$(sm),code=sm_
 
 ifeq ($(SMS),)
 # Generate PTX code from SM 20
-GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
+#GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
 endif
 
 # Generate PTX code from the highest SM architecture in $(SMS) to guarantee forward-compatibility

--- a/cuda-samples/0_Simple/simpleAssert/Makefile
+++ b/cuda-samples/0_Simple/simpleAssert/Makefile
@@ -196,9 +196,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/simpleAtomicIntrinsics/Makefile
+++ b/cuda-samples/0_Simple/simpleAtomicIntrinsics/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/simpleCallback/Makefile
+++ b/cuda-samples/0_Simple/simpleCallback/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/simpleCubemapTexture/Makefile
+++ b/cuda-samples/0_Simple/simpleCubemapTexture/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/simpleIPC/Makefile
+++ b/cuda-samples/0_Simple/simpleIPC/Makefile
@@ -202,9 +202,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/simpleLayeredTexture/Makefile
+++ b/cuda-samples/0_Simple/simpleLayeredTexture/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/simpleMPI/Makefile
+++ b/cuda-samples/0_Simple/simpleMPI/Makefile
@@ -227,9 +227,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/simpleMultiCopy/Makefile
+++ b/cuda-samples/0_Simple/simpleMultiCopy/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/simpleMultiGPU/Makefile
+++ b/cuda-samples/0_Simple/simpleMultiGPU/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/simpleMultiGPU/test/0_Simple/simpleMultiGPU/Makefile
+++ b/cuda-samples/0_Simple/simpleMultiGPU/test/0_Simple/simpleMultiGPU/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/simpleOccupancy/Makefile
+++ b/cuda-samples/0_Simple/simpleOccupancy/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/simpleP2P/Makefile
+++ b/cuda-samples/0_Simple/simpleP2P/Makefile
@@ -196,9 +196,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/simplePitchLinearTexture/Makefile
+++ b/cuda-samples/0_Simple/simplePitchLinearTexture/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/simplePrintf/Makefile
+++ b/cuda-samples/0_Simple/simplePrintf/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/simpleSeparateCompilation/Makefile
+++ b/cuda-samples/0_Simple/simpleSeparateCompilation/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/simpleStreams/Makefile
+++ b/cuda-samples/0_Simple/simpleStreams/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/simpleSurfaceWrite/Makefile
+++ b/cuda-samples/0_Simple/simpleSurfaceWrite/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/simpleTemplates/Makefile
+++ b/cuda-samples/0_Simple/simpleTemplates/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/simpleTexture/Makefile
+++ b/cuda-samples/0_Simple/simpleTexture/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/simpleTextureDrv/Makefile
+++ b/cuda-samples/0_Simple/simpleTextureDrv/Makefile
@@ -201,7 +201,7 @@ $(foreach sm,$(SMS),$(eval GENCODE_FLAGS += -gencode arch=compute_$(sm),code=sm_
 
 ifeq ($(SMS),)
 # Generate PTX code from SM 20
-GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
+#GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
 endif
 
 # Generate PTX code from the highest SM architecture in $(SMS) to guarantee forward-compatibility

--- a/cuda-samples/0_Simple/simpleVoteIntrinsics/Makefile
+++ b/cuda-samples/0_Simple/simpleVoteIntrinsics/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/simpleZeroCopy/Makefile
+++ b/cuda-samples/0_Simple/simpleZeroCopy/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/template/Makefile
+++ b/cuda-samples/0_Simple/template/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/template_runtime/Makefile
+++ b/cuda-samples/0_Simple/template_runtime/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/vectorAdd/Makefile
+++ b/cuda-samples/0_Simple/vectorAdd/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/0_Simple/vectorAddDrv/Makefile
+++ b/cuda-samples/0_Simple/vectorAddDrv/Makefile
@@ -201,7 +201,7 @@ $(foreach sm,$(SMS),$(eval GENCODE_FLAGS += -gencode arch=compute_$(sm),code=sm_
 
 ifeq ($(SMS),)
 # Generate PTX code from SM 20
-GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
+#GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
 endif
 
 # Generate PTX code from the highest SM architecture in $(SMS) to guarantee forward-compatibility

--- a/cuda-samples/1_Utilities/bandwidthTest/Makefile
+++ b/cuda-samples/1_Utilities/bandwidthTest/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/1_Utilities/deviceQuery/Makefile
+++ b/cuda-samples/1_Utilities/deviceQuery/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/1_Utilities/deviceQueryDrv/Makefile
+++ b/cuda-samples/1_Utilities/deviceQueryDrv/Makefile
@@ -199,7 +199,7 @@ $(foreach sm,$(SMS),$(eval GENCODE_FLAGS += -gencode arch=compute_$(sm),code=sm_
 
 ifeq ($(SMS),)
 # Generate PTX code from SM 20
-GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
+#GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
 endif
 
 # Generate PTX code from the highest SM architecture in $(SMS) to guarantee forward-compatibility

--- a/cuda-samples/1_Utilities/p2pBandwidthLatencyTest/Makefile
+++ b/cuda-samples/1_Utilities/p2pBandwidthLatencyTest/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/2_Graphics/Mandelbrot/Makefile
+++ b/cuda-samples/2_Graphics/Mandelbrot/Makefile
@@ -204,9 +204,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/2_Graphics/marchingCubes/Makefile
+++ b/cuda-samples/2_Graphics/marchingCubes/Makefile
@@ -204,9 +204,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/2_Graphics/marchingCubes/marchingCubes_kernel.cu
+++ b/cuda-samples/2_Graphics/marchingCubes/marchingCubes_kernel.cu
@@ -236,7 +236,7 @@ generateTriangles(float4 *pos, float4 *norm, uint *compactedVoxelArray, uint *nu
 
     if (i > activeVoxels - 1)
     {
-        // can't return here because of syncthreads()
+        // can't return here because of __syncthreads()
         i = activeVoxels - 1;
     }
 

--- a/cuda-samples/2_Graphics/simpleGL/Makefile
+++ b/cuda-samples/2_Graphics/simpleGL/Makefile
@@ -204,9 +204,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/2_Graphics/simpleTexture3D/Makefile
+++ b/cuda-samples/2_Graphics/simpleTexture3D/Makefile
@@ -204,9 +204,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/2_Graphics/volumeFiltering/Makefile
+++ b/cuda-samples/2_Graphics/volumeFiltering/Makefile
@@ -204,9 +204,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/2_Graphics/volumeRender/Makefile
+++ b/cuda-samples/2_Graphics/volumeRender/Makefile
@@ -204,9 +204,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/3_Imaging/HSOpticalFlow/Makefile
+++ b/cuda-samples/3_Imaging/HSOpticalFlow/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/3_Imaging/SobelFilter/Makefile
+++ b/cuda-samples/3_Imaging/SobelFilter/Makefile
@@ -204,9 +204,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/3_Imaging/bicubicTexture/Makefile
+++ b/cuda-samples/3_Imaging/bicubicTexture/Makefile
@@ -204,9 +204,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/3_Imaging/bilateralFilter/Makefile
+++ b/cuda-samples/3_Imaging/bilateralFilter/Makefile
@@ -204,9 +204,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/3_Imaging/boxFilter/Makefile
+++ b/cuda-samples/3_Imaging/boxFilter/Makefile
@@ -204,9 +204,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/3_Imaging/convolutionFFT2D/Makefile
+++ b/cuda-samples/3_Imaging/convolutionFFT2D/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/3_Imaging/convolutionSeparable/Makefile
+++ b/cuda-samples/3_Imaging/convolutionSeparable/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/3_Imaging/convolutionTexture/Makefile
+++ b/cuda-samples/3_Imaging/convolutionTexture/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/3_Imaging/cudaDecodeGL/Makefile
+++ b/cuda-samples/3_Imaging/cudaDecodeGL/Makefile
@@ -227,7 +227,7 @@ $(foreach sm,$(SMS),$(eval GENCODE_FLAGS += -gencode arch=compute_$(sm),code=sm_
 
 ifeq ($(SMS),)
 # Generate PTX code from SM 20
-GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
+#GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
 endif
 
 # Generate PTX code from the highest SM architecture in $(SMS) to guarantee forward-compatibility

--- a/cuda-samples/3_Imaging/dct8x8/Makefile
+++ b/cuda-samples/3_Imaging/dct8x8/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/3_Imaging/dwtHaar1D/Makefile
+++ b/cuda-samples/3_Imaging/dwtHaar1D/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/3_Imaging/dwtHaar1D/dwtHaar1D_kernel.cuh
+++ b/cuda-samples/3_Imaging/dwtHaar1D/dwtHaar1D_kernel.cuh
@@ -148,7 +148,7 @@ dwtHaar1D(float *id, float *od, float *approx_final,
     // early out if possible
     // the compiler removes this part from the source because dlevels is
     // a constant shader input
-    // note: syncthreads in bodies of branches can lead to dead-locks unless the
+    // note: __syncthreads in bodies of branches can lead to dead-locks unless the
     // the condition evaluates the same way for ALL threads of a block, as in
     // this case
     if (dlevels > 1)

--- a/cuda-samples/3_Imaging/dxtc/Makefile
+++ b/cuda-samples/3_Imaging/dxtc/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/3_Imaging/histogram/Makefile
+++ b/cuda-samples/3_Imaging/histogram/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/3_Imaging/imageDenoising/Makefile
+++ b/cuda-samples/3_Imaging/imageDenoising/Makefile
@@ -204,9 +204,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/3_Imaging/postProcessGL/Makefile
+++ b/cuda-samples/3_Imaging/postProcessGL/Makefile
@@ -204,9 +204,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/3_Imaging/recursiveGaussian/Makefile
+++ b/cuda-samples/3_Imaging/recursiveGaussian/Makefile
@@ -204,9 +204,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/3_Imaging/simpleCUDA2GL/Makefile
+++ b/cuda-samples/3_Imaging/simpleCUDA2GL/Makefile
@@ -204,9 +204,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/3_Imaging/stereoDisparity/Makefile
+++ b/cuda-samples/3_Imaging/stereoDisparity/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/4_Finance/BlackScholes/Makefile
+++ b/cuda-samples/4_Finance/BlackScholes/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)
@@ -211,7 +211,7 @@ GENCODE_FLAGS += -gencode arch=compute_$(HIGHEST_SM),code=compute_$(HIGHEST_SM)
 endif
 endif
 
-ALL_CCFLAGS += -po maxrregcount=16
+#ALL_CCFLAGS += -po maxrregcount=16
 
 ifeq ($(SAMPLE_ENABLED),0)
 EXEC ?= @echo "[@]"

--- a/cuda-samples/4_Finance/MonteCarloMultiGPU/Makefile
+++ b/cuda-samples/4_Finance/MonteCarloMultiGPU/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/4_Finance/SobolQRNG/Makefile
+++ b/cuda-samples/4_Finance/SobolQRNG/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/4_Finance/binomialOptions/Makefile
+++ b/cuda-samples/4_Finance/binomialOptions/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/4_Finance/quasirandomGenerator/Makefile
+++ b/cuda-samples/4_Finance/quasirandomGenerator/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/5_Simulations/fluidsGL/Makefile
+++ b/cuda-samples/5_Simulations/fluidsGL/Makefile
@@ -204,9 +204,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/5_Simulations/nbody/Makefile
+++ b/cuda-samples/5_Simulations/nbody/Makefile
@@ -204,9 +204,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/5_Simulations/nbody_screen/Makefile
+++ b/cuda-samples/5_Simulations/nbody_screen/Makefile
@@ -212,9 +212,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/5_Simulations/oceanFFT/Makefile
+++ b/cuda-samples/5_Simulations/oceanFFT/Makefile
@@ -204,9 +204,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/5_Simulations/particles/Makefile
+++ b/cuda-samples/5_Simulations/particles/Makefile
@@ -204,9 +204,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/5_Simulations/smokeParticles/Makefile
+++ b/cuda-samples/5_Simulations/smokeParticles/Makefile
@@ -204,9 +204,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/6_Advanced/FDTD3d/Makefile
+++ b/cuda-samples/6_Advanced/FDTD3d/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/6_Advanced/FunctionPointers/Makefile
+++ b/cuda-samples/6_Advanced/FunctionPointers/Makefile
@@ -204,9 +204,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/6_Advanced/alignedTypes/Makefile
+++ b/cuda-samples/6_Advanced/alignedTypes/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/6_Advanced/concurrentKernels/Makefile
+++ b/cuda-samples/6_Advanced/concurrentKernels/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/6_Advanced/concurrentKernels/concurrentKernels.cu
+++ b/cuda-samples/6_Advanced/concurrentKernels/concurrentKernels.cu
@@ -62,7 +62,7 @@ __global__ void sum(clock_t *d_clocks, int N)
     }
 
     s_clocks[threadIdx.x] = my_sum;
-    syncthreads();
+    __syncthreads();
 
     for (int i=16; i>0; i/=2)
     {
@@ -71,7 +71,7 @@ __global__ void sum(clock_t *d_clocks, int N)
             s_clocks[threadIdx.x] += s_clocks[threadIdx.x + i];
         }
 
-        syncthreads();
+        __syncthreads();
     }
 
     d_clocks[0] = s_clocks[0];

--- a/cuda-samples/6_Advanced/eigenvalues/Makefile
+++ b/cuda-samples/6_Advanced/eigenvalues/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/6_Advanced/fastWalshTransform/Makefile
+++ b/cuda-samples/6_Advanced/fastWalshTransform/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/6_Advanced/interval/Makefile
+++ b/cuda-samples/6_Advanced/interval/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/6_Advanced/lineOfSight/Makefile
+++ b/cuda-samples/6_Advanced/lineOfSight/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/6_Advanced/matrixMulDynlinkJIT/Makefile
+++ b/cuda-samples/6_Advanced/matrixMulDynlinkJIT/Makefile
@@ -195,7 +195,7 @@ $(foreach sm,$(SMS),$(eval GENCODE_FLAGS += -gencode arch=compute_$(sm),code=sm_
 
 ifeq ($(SMS),)
 # Generate PTX code from SM 20
-GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
+#GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
 endif
 
 # Generate PTX code from the highest SM architecture in $(SMS) to guarantee forward-compatibility

--- a/cuda-samples/6_Advanced/mergeSort/Makefile
+++ b/cuda-samples/6_Advanced/mergeSort/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/6_Advanced/newdelete/Makefile
+++ b/cuda-samples/6_Advanced/newdelete/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/6_Advanced/ptxjit/Makefile
+++ b/cuda-samples/6_Advanced/ptxjit/Makefile
@@ -199,7 +199,7 @@ $(foreach sm,$(SMS),$(eval GENCODE_FLAGS += -gencode arch=compute_$(sm),code=sm_
 
 ifeq ($(SMS),)
 # Generate PTX code from SM 20
-GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
+#GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
 endif
 
 # Generate PTX code from the highest SM architecture in $(SMS) to guarantee forward-compatibility

--- a/cuda-samples/6_Advanced/radixSortThrust/Makefile
+++ b/cuda-samples/6_Advanced/radixSortThrust/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/6_Advanced/reduction/Makefile
+++ b/cuda-samples/6_Advanced/reduction/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/6_Advanced/scalarProd/Makefile
+++ b/cuda-samples/6_Advanced/scalarProd/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/6_Advanced/scan/Makefile
+++ b/cuda-samples/6_Advanced/scan/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/6_Advanced/segmentationTreeThrust/Makefile
+++ b/cuda-samples/6_Advanced/segmentationTreeThrust/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/6_Advanced/simpleHyperQ/Makefile
+++ b/cuda-samples/6_Advanced/simpleHyperQ/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/6_Advanced/sortingNetworks/Makefile
+++ b/cuda-samples/6_Advanced/sortingNetworks/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/6_Advanced/threadFenceReduction/Makefile
+++ b/cuda-samples/6_Advanced/threadFenceReduction/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/6_Advanced/threadMigration/Makefile
+++ b/cuda-samples/6_Advanced/threadMigration/Makefile
@@ -201,7 +201,7 @@ $(foreach sm,$(SMS),$(eval GENCODE_FLAGS += -gencode arch=compute_$(sm),code=sm_
 
 ifeq ($(SMS),)
 # Generate PTX code from SM 20
-GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
+#GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
 endif
 
 # Generate PTX code from the highest SM architecture in $(SMS) to guarantee forward-compatibility

--- a/cuda-samples/6_Advanced/transpose/Makefile
+++ b/cuda-samples/6_Advanced/transpose/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/7_CUDALibraries/MC_EstimatePiInlineP/Makefile
+++ b/cuda-samples/7_CUDALibraries/MC_EstimatePiInlineP/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/7_CUDALibraries/MC_EstimatePiInlineQ/Makefile
+++ b/cuda-samples/7_CUDALibraries/MC_EstimatePiInlineQ/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/7_CUDALibraries/MC_EstimatePiP/Makefile
+++ b/cuda-samples/7_CUDALibraries/MC_EstimatePiP/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/7_CUDALibraries/MC_EstimatePiQ/Makefile
+++ b/cuda-samples/7_CUDALibraries/MC_EstimatePiQ/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/7_CUDALibraries/MC_SingleAsianOptionP/Makefile
+++ b/cuda-samples/7_CUDALibraries/MC_SingleAsianOptionP/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/7_CUDALibraries/MersenneTwisterGP11213/Makefile
+++ b/cuda-samples/7_CUDALibraries/MersenneTwisterGP11213/Makefile
@@ -195,7 +195,7 @@ $(foreach sm,$(SMS),$(eval GENCODE_FLAGS += -gencode arch=compute_$(sm),code=sm_
 
 ifeq ($(SMS),)
 # Generate PTX code from SM 20
-GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
+#GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
 endif
 
 # Generate PTX code from the highest SM architecture in $(SMS) to guarantee forward-compatibility

--- a/cuda-samples/7_CUDALibraries/batchCUBLAS/Makefile
+++ b/cuda-samples/7_CUDALibraries/batchCUBLAS/Makefile
@@ -195,7 +195,7 @@ $(foreach sm,$(SMS),$(eval GENCODE_FLAGS += -gencode arch=compute_$(sm),code=sm_
 
 ifeq ($(SMS),)
 # Generate PTX code from SM 20
-GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
+#GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
 endif
 
 # Generate PTX code from the highest SM architecture in $(SMS) to guarantee forward-compatibility

--- a/cuda-samples/7_CUDALibraries/boxFilterNPP/Makefile
+++ b/cuda-samples/7_CUDALibraries/boxFilterNPP/Makefile
@@ -197,7 +197,7 @@ $(foreach sm,$(SMS),$(eval GENCODE_FLAGS += -gencode arch=compute_$(sm),code=sm_
 
 ifeq ($(SMS),)
 # Generate PTX code from SM 20
-GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
+#GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
 endif
 
 # Generate PTX code from the highest SM architecture in $(SMS) to guarantee forward-compatibility

--- a/cuda-samples/7_CUDALibraries/conjugateGradient/Makefile
+++ b/cuda-samples/7_CUDALibraries/conjugateGradient/Makefile
@@ -195,7 +195,7 @@ $(foreach sm,$(SMS),$(eval GENCODE_FLAGS += -gencode arch=compute_$(sm),code=sm_
 
 ifeq ($(SMS),)
 # Generate PTX code from SM 20
-GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
+#GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
 endif
 
 # Generate PTX code from the highest SM architecture in $(SMS) to guarantee forward-compatibility

--- a/cuda-samples/7_CUDALibraries/conjugateGradientPrecond/Makefile
+++ b/cuda-samples/7_CUDALibraries/conjugateGradientPrecond/Makefile
@@ -195,7 +195,7 @@ $(foreach sm,$(SMS),$(eval GENCODE_FLAGS += -gencode arch=compute_$(sm),code=sm_
 
 ifeq ($(SMS),)
 # Generate PTX code from SM 20
-GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
+#GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
 endif
 
 # Generate PTX code from the highest SM architecture in $(SMS) to guarantee forward-compatibility

--- a/cuda-samples/7_CUDALibraries/cuHook/Makefile
+++ b/cuda-samples/7_CUDALibraries/cuHook/Makefile
@@ -204,9 +204,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/7_CUDALibraries/freeImageInteropNPP/Makefile
+++ b/cuda-samples/7_CUDALibraries/freeImageInteropNPP/Makefile
@@ -197,7 +197,7 @@ $(foreach sm,$(SMS),$(eval GENCODE_FLAGS += -gencode arch=compute_$(sm),code=sm_
 
 ifeq ($(SMS),)
 # Generate PTX code from SM 20
-GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
+#GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
 endif
 
 # Generate PTX code from the highest SM architecture in $(SMS) to guarantee forward-compatibility

--- a/cuda-samples/7_CUDALibraries/grabcutNPP/Makefile
+++ b/cuda-samples/7_CUDALibraries/grabcutNPP/Makefile
@@ -204,9 +204,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/7_CUDALibraries/histEqualizationNPP/Makefile
+++ b/cuda-samples/7_CUDALibraries/histEqualizationNPP/Makefile
@@ -197,7 +197,7 @@ $(foreach sm,$(SMS),$(eval GENCODE_FLAGS += -gencode arch=compute_$(sm),code=sm_
 
 ifeq ($(SMS),)
 # Generate PTX code from SM 20
-GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
+#GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
 endif
 
 # Generate PTX code from the highest SM architecture in $(SMS) to guarantee forward-compatibility

--- a/cuda-samples/7_CUDALibraries/imageSegmentationNPP/Makefile
+++ b/cuda-samples/7_CUDALibraries/imageSegmentationNPP/Makefile
@@ -197,7 +197,7 @@ $(foreach sm,$(SMS),$(eval GENCODE_FLAGS += -gencode arch=compute_$(sm),code=sm_
 
 ifeq ($(SMS),)
 # Generate PTX code from SM 20
-GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
+#GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
 endif
 
 # Generate PTX code from the highest SM architecture in $(SMS) to guarantee forward-compatibility

--- a/cuda-samples/7_CUDALibraries/jpegNPP/Makefile
+++ b/cuda-samples/7_CUDALibraries/jpegNPP/Makefile
@@ -197,7 +197,7 @@ $(foreach sm,$(SMS),$(eval GENCODE_FLAGS += -gencode arch=compute_$(sm),code=sm_
 
 ifeq ($(SMS),)
 # Generate PTX code from SM 20
-GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
+#GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
 endif
 
 # Generate PTX code from the highest SM architecture in $(SMS) to guarantee forward-compatibility

--- a/cuda-samples/7_CUDALibraries/randomFog/Makefile
+++ b/cuda-samples/7_CUDALibraries/randomFog/Makefile
@@ -211,7 +211,7 @@ $(foreach sm,$(SMS),$(eval GENCODE_FLAGS += -gencode arch=compute_$(sm),code=sm_
 
 ifeq ($(SMS),)
 # Generate PTX code from SM 20
-GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
+#GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
 endif
 
 # Generate PTX code from the highest SM architecture in $(SMS) to guarantee forward-compatibility

--- a/cuda-samples/7_CUDALibraries/simpleCUBLAS/Makefile
+++ b/cuda-samples/7_CUDALibraries/simpleCUBLAS/Makefile
@@ -195,7 +195,7 @@ $(foreach sm,$(SMS),$(eval GENCODE_FLAGS += -gencode arch=compute_$(sm),code=sm_
 
 ifeq ($(SMS),)
 # Generate PTX code from SM 20
-GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
+#GENCODE_FLAGS += -gencode arch=compute_20,code=compute_20
 endif
 
 # Generate PTX code from the highest SM architecture in $(SMS) to guarantee forward-compatibility

--- a/cuda-samples/7_CUDALibraries/simpleCUFFT/Makefile
+++ b/cuda-samples/7_CUDALibraries/simpleCUFFT/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/7_CUDALibraries/simpleCUFFT_2d_MGPU/Makefile
+++ b/cuda-samples/7_CUDALibraries/simpleCUFFT_2d_MGPU/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/7_CUDALibraries/simpleCUFFT_MGPU/Makefile
+++ b/cuda-samples/7_CUDALibraries/simpleCUFFT_MGPU/Makefile
@@ -190,9 +190,9 @@ SAMPLE_ENABLED := 1
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 37 50 52
+SMS ?= 30 32 35 37 50 52
 else
-SMS ?= 20 30 35 37 50 52
+SMS ?= 30 35 37 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/7_CUDALibraries/simpleCUFFT_callback/Makefile
+++ b/cuda-samples/7_CUDALibraries/simpleCUFFT_callback/Makefile
@@ -196,9 +196,9 @@ endif
 
 # Gencode arguments
 ifeq ($(TARGET_ARCH),armv7l)
-SMS ?= 20 30 32 35 50 52
+SMS ?= 30 32 35 50 52
 else
-SMS ?= 20 30 35 50 52
+SMS ?= 30 35 50 52
 endif
 
 ifeq ($(SMS),)

--- a/cuda-samples/Makefile
+++ b/cuda-samples/Makefile
@@ -38,7 +38,7 @@ TARGET_ARCH ?= $(shell uname -m)
 # Project folders that contain CUDA samples
 PROJECTS ?= $(shell find 0_Simple 1_Utilities 2_Graphics 3_Imaging 4_Finance 5_Simulations 6_Advanced 7_CUDALibraries -name Makefile)
 
-FILTER_OUT :=
+FILTER_OUT := 7_CUDALibraries/cuHook/Makefile #This demo is currently broken
 
 ifeq ($(TARGET_ARCH),ppc64le)
 FILTER_OUT += 2_Graphics/simpleGLES_screen/Makefile

--- a/cuda-samples/default.nix
+++ b/cuda-samples/default.nix
@@ -5,7 +5,7 @@ in rec {
   examplecuda = stdenv.mkDerivation rec {
     name = "example-cuda";
     src = ./.;
-    buildInputs = [ pkgs.cudatoolkit pkgs.linuxPackages.nvidia_x11 pkgs.makeWrapper ];
+    buildInputs = [ pkgs.cudatoolkit pkgs.linuxPackages_4_16.nvidia_x11 pkgs.makeWrapper ];
 
     preBuild = ''
       export CUDA_PATH="${pkgs.cudatoolkit}"
@@ -18,7 +18,7 @@ in rec {
       for file in `ls $out/bin`; do
       	  echo "$file";
 	  wrapProgram "$out/bin/$file" \
-	              --prefix LD_LIBRARY_PATH ":" "${pkgs.linuxPackages.nvidia_x11}/lib"
+	              --prefix LD_LIBRARY_PATH ":" "${pkgs.linuxPackages_4_16.nvidia_x11}/lib"
       done
     '';
 

--- a/cuda-samples/default.nix
+++ b/cuda-samples/default.nix
@@ -5,7 +5,7 @@ in rec {
   examplecuda = stdenv.mkDerivation rec {
     name = "example-cuda";
     src = ./.;
-    buildInputs = [ pkgs.cudatoolkit pkgs.linuxPackages_4_16.nvidia_x11 pkgs.makeWrapper ];
+    buildInputs = [ pkgs.cudatoolkit pkgs.linuxPackages.nvidia_x11 pkgs.makeWrapper ];
 
     preBuild = ''
       export CUDA_PATH="${pkgs.cudatoolkit}"
@@ -15,10 +15,10 @@ in rec {
       mkdir -p "$out/bin"
       cp -r ./bin/*/*/release/* "$out/bin"
 
-      for file in `ls $out/bin`; do
+      for file in `ls $out/bin | grep -v '\.'`; do
       	  echo "$file";
 	  wrapProgram "$out/bin/$file" \
-	              --prefix LD_LIBRARY_PATH ":" "${pkgs.linuxPackages_4_16.nvidia_x11}/lib"
+	              --prefix LD_LIBRARY_PATH ":" "${pkgs.linuxPackages.nvidia_x11}/lib"
       done
     '';
 


### PR DESCRIPTION
The master branch wouldn't build for me on Nixos 18.03 with cudatoolkit 9.1. This PR fixes compatibility with my configuration. Since it:
- removes compatibility with older (Fermi) hardware
- removes compatibility with older versions of the cudatoolkit (I'm not sure when syncthreads got renamed to __syncthreads)
- disables one example I couldn't get working
I did not merge with master.